### PR TITLE
Fix guesser RNG order

### DIFF
--- a/index.html
+++ b/index.html
@@ -183,11 +183,21 @@
         return;
       }
 
-      const guess = document.getElementById("single-choice").value;
-      const actual = getSymbolFromWebcam();
-      if (!actual) {
-        document.getElementById("result").innerText = "Insufficient random bits — try again.";
-        return;
+      let guess, actual;
+      if (mode === 'guesser') {
+        actual = getSymbolFromWebcam();
+        if (!actual) {
+          document.getElementById("result").innerText = "Insufficient random bits — try again.";
+          return;
+        }
+        guess = document.getElementById("single-choice").value;
+      } else {
+        guess = document.getElementById("single-choice").value;
+        actual = getSymbolFromWebcam();
+        if (!actual) {
+          document.getElementById("result").innerText = "Insufficient random bits — try again.";
+          return;
+        }
       }
       const match = (actual === guess);
       document.getElementById("result").innerHTML =


### PR DESCRIPTION
## Summary
- update guesser mode so the RNG value is generated before reading the user's guess

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68556391a20c8326a576b7f3bea60442