### PR TITLE
Adjust chart layout and background

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,8 @@
     .premonition-choice { margin: 5px; }
     #premonition-inputs { margin-top: 10px; }
     canvas { background: #222; border: 1px solid #444; margin-top: 20px; }
+    #chart { background: #fff; }
+    #live-container { display: flex; justify-content: center; gap: 20px; }
   </style>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jstat/1.9.4/jstat.min.js"></script>
@@ -77,9 +79,10 @@
   <button onclick="exportCSV()">Export CSV</button>
 
   <div id="result"></div>
-  <canvas id="chart" width="600" height="300"></canvas>
-
-  <video id="video" width="320" height="240" autoplay muted></video>
+  <div id="live-container">
+    <canvas id="chart" width="320" height="160"></canvas>
+    <video id="video" width="320" height="240" autoplay muted></video>
+  </div>
   <canvas id="canvas" width="320" height="240" style="display:none;"></canvas>
 
   <script type="module">


### PR DESCRIPTION
## Summary
- use flex container to keep live chart and camera on one line
- shrink chart canvas and set its background to white

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68556bcb88748326ade40bda279a5d62