### PR TITLE
Add username and email inputs

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,16 @@
   <h1>Quantum RNG Web Portal</h1>
 
   <div>
+    <label>Username:</label>
+    <input type="text" id="username" value="unidentified" />
+  </div>
+
+  <div>
+    <label>Email:</label>
+    <input type="email" id="email" value="unidentified" />
+  </div>
+
+  <div>
     <label>Select Mode:</label>
     <select id="mode">
       <option value="focus">Focus</option>
@@ -180,6 +190,8 @@
 
     async function runTrial() {
       const mode = document.getElementById("mode").value;
+      const username = document.getElementById("username").value.trim() || 'unidentified';
+      const email = document.getElementById("email").value.trim() || 'unidentified';
       if (mode === 'premonition') {
         const guesses = [];
         for (let i = 1; i <= 5; i++) {
@@ -194,7 +206,7 @@
           }
           const match = (actual === guess);
           results.push({ guess, actual, match });
-          addDoc(collection(db, 'qrng_trials'), { timestamp: serverTimestamp(), mode, userSymbol: guess, actualSymbol: actual, match })
+          addDoc(collection(db, 'qrng_trials'), { timestamp: serverTimestamp(), mode, userSymbol: guess, actualSymbol: actual, match, username, email })
             .catch(e => console.error(e));
         }
         let summary = '';
@@ -234,7 +246,7 @@
         `Your ${mode==='focus'?'focus':'guess'}: <b>${guess}</b><br>
          Actual: <b>${actual}</b><br>
          <span class='${match?'match':'no-match'}'>${match?'✔ Match!':'✘ No match'}</span>`;
-      addDoc(collection(db, 'qrng_trials'), { timestamp: serverTimestamp(), mode, userSymbol: guess, actualSymbol: actual, match })
+      addDoc(collection(db, 'qrng_trials'), { timestamp: serverTimestamp(), mode, userSymbol: guess, actualSymbol: actual, match, username, email })
         .catch(e => console.error(e));
     }
 
@@ -242,7 +254,7 @@
       const modeFilter = prompt("Filter (focus, guesser, premonition) or leave blank:").toLowerCase();
       const snap = await getDocs(collection(db, 'qrng_trials'));
       const data = {Red:0,Blue:0,Green:0,Yellow:0}, total={Red:0,Blue:0,Green:0,Yellow:0}, rows=[];
-      snap.forEach(d => { const e = d.data(); if(modeFilter && e.mode!==modeFilter) return; if(e.userSymbol in total){ total[e.userSymbol]++; if(e.match) data[e.userSymbol]++; rows.push([e.timestamp?.toDate().toISOString()||'', e.mode, e.userSymbol, e.actualSymbol, e.match]); }});
+      snap.forEach(d => { const e = d.data(); if(modeFilter && e.mode!==modeFilter) return; if(e.userSymbol in total){ total[e.userSymbol]++; if(e.match) data[e.userSymbol]++; rows.push([e.timestamp?.toDate().toISOString()||'', e.username||'', e.email||'', e.mode, e.userSymbol, e.actualSymbol, e.match]); }});
       const labels = SYMBOLS;
       const matches = labels.map(s=>data[s]);
       const attempts = labels.map(s=>total[s]);
@@ -257,7 +269,7 @@
         const ci = n?`±${(z*Math.sqrt((k/n)*(1-k/n)/n)*100).toFixed(1)}`:'±0';
         return {s,n,k,rate,pval,power,ci};
       });
-      let csv='timestamp,mode,userSymbol,actualSymbol,match\n'+rows.map(r=>r.join(',')).join('\n')+'\n\nSymbol,N,Matches,Rate%,CI,p-value,Power\n'+stats.map(x=>`${x.s},${x.n},${x.k},${x.rate},${x.ci},${x.pval},${x.power}`).join('\n');
+      let csv='timestamp,username,email,mode,userSymbol,actualSymbol,match\n'+rows.map(r=>r.join(',')).join('\n')+'\n\nSymbol,N,Matches,Rate%,CI,p-value,Power\n'+stats.map(x=>`${x.s},${x.n},${x.k},${x.rate},${x.ci},${x.pval},${x.power}`).join('\n');
       const blob=new Blob([csv],{type:'text/csv'}), url=URL.createObjectURL(blob), a=document.createElement('a');
       a.href=url; a.download=`qrng_${modeFilter||'all'}.csv`; a.click(); URL.revokeObjectURL(url);
     }


### PR DESCRIPTION
## Summary
- allow users to provide optional username and email
- store username and email with each trial result
- export CSV with username and email columns

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68556cdc5b748326b748ad68b11ce9e2