### PR TITLE
Remove cumulative tracker from premonition summary

### DIFF
--- a/index.html
+++ b/index.html
@@ -227,7 +227,6 @@
         premonitionStats.totalMatches += matchCount;
         premonitionStats.totalTrials += 5;
         summary += `<b>Round ${premonitionStats.round}: ${matchCount}/5 correct</b><br>`;
-        summary += `<b>Cumulative: ${premonitionStats.totalMatches}/${premonitionStats.totalTrials} correct</b>`;
         document.getElementById("result").innerHTML = summary;
         document.querySelectorAll('.premonition-choice').forEach(sel => sel.selectedIndex = 0);
         return;


### PR DESCRIPTION
## Summary
- remove `Cumulative` tracker text from premonition mode summary

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`
- `cargo test` *(fails: could not find `Cargo.toml`)*

------
https://chatgpt.com/codex/tasks/task_e_685570c7455083269bd37edd00a07b9b