### PR TITLE
Implement continuous focus mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,7 +94,7 @@
     </select>
   </div>
 
-  <button onclick="runTrial()">Start Trial</button>
+  <button onclick="runTrial()" id="trial-button">Start Trial</button>
   <button onclick="exportCSV()">Export CSV</button>
 
   <div id="result"></div>
@@ -128,6 +128,7 @@
     const ctx = canvas.getContext("2d");
     let premonitionStats = {round:0,totalMatches:0,totalTrials:0};
     let chartInstance = null;
+    let focusRunning = false;
 
     function updateChart(snapshot) {
       const data = {Red:0,Blue:0,Green:0,Yellow:0},
@@ -218,10 +219,50 @@
       return getSymbolFromWebcam();
     }
 
+    async function singleFocusTrial(username, email) {
+      const guess = document.getElementById("single-choice").value;
+      const actual = getSymbol();
+      if (!actual) {
+        document.getElementById("result").innerText = "Insufficient random bits — try again.";
+        return;
+      }
+      const match = (actual === guess);
+      document.getElementById("result").innerHTML =
+        `Your focus: <b>${guess}</b><br>` +
+        `Actual: <b>${actual}</b><br>` +
+        `<span class='${match?'match':'no-match'}'>${match?'✔ Match!':'✘ No match'}</span>`;
+      addDoc(collection(db, 'qrng_trials'), { timestamp: serverTimestamp(), mode:'focus', userSymbol: guess, actualSymbol: actual, match, username, email })
+        .catch(e => console.error(e));
+    }
+
+    function startFocusLoop(username, email) {
+      focusRunning = true;
+      document.getElementById('trial-button').innerText = 'Stop Trial';
+      const loop = async () => {
+        if (!focusRunning) return;
+        await singleFocusTrial(username, email);
+        setTimeout(loop, 200);
+      };
+      loop();
+    }
+
+    function stopFocusLoop() {
+      focusRunning = false;
+      document.getElementById('trial-button').innerText = 'Start Trial';
+    }
+
     async function runTrial() {
       const mode = document.getElementById("mode").value;
       const username = document.getElementById("username").value.trim() || 'unidentified';
       const email = document.getElementById("email").value.trim() || 'unidentified';
+      if (mode === 'focus') {
+        if (focusRunning) {
+          stopFocusLoop();
+        } else {
+          startFocusLoop(username, email);
+        }
+        return;
+      }
       if (mode === 'premonition') {
         const guesses = [];
         for (let i = 1; i <= 5; i++) {


### PR DESCRIPTION
## Summary
- add `id="trial-button"` to allow toggling button text
- add `focusRunning` state and helpers to run/stopt focus mode in a loop
- handle start/stop inside `runTrial`

## Testing
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_685571b5473483269974a0f03f8752ec