### PR TITLE
Update CSV export and record hashing

### DIFF
--- a/index.html
+++ b/index.html
@@ -346,10 +346,10 @@
           const rng = document.getElementById("rng").value === 'event' ? 'Software' : 'Camera';
           const match = (actual === g.guess);
           results.push({ guess: g.guess, actual, match });
-          const record = { timestamp: g.timestamp, submitTimestamp: g.timestamp, rngTimestamp, mode, rng, userSymbol: g.guess, actualSymbol: actual, match, username, submitHash: g.submitHash };
+          const record = { timestamp: g.timestamp, rngTimestamp, mode, rng, userSymbol: g.guess, actualSymbol: actual, match, username, submitHash: g.submitHash };
           const rngHash = await computeHash({ timestamp: rngTimestamp.toISOString(), mode, rng, actualSymbol: actual });
           record.rngHash = rngHash;
-          const hash = await computeHash({ ...record, timestamp: record.submitTimestamp.toISOString(), rngTimestamp: record.rngTimestamp.toISOString() });
+          const hash = await computeHash({ ...record, timestamp: record.timestamp.toISOString(), rngTimestamp: record.rngTimestamp.toISOString() });
           record.hash = hash;
           addDoc(collection(db, 'qrng_trials'), record)
             .catch(e => console.error(e));
@@ -395,8 +395,8 @@
          <span class='${match?'match':'no-match'}'>${match?'✔ Match!':'✘ No match'}</span>`;
       const submitHash = await computeHash({ timestamp: submitTimestamp.toISOString(), mode, userSymbol: guess, username });
       const rngHash = await computeHash({ timestamp: rngTimestamp.toISOString(), mode, rng, actualSymbol: actual });
-      const record = { timestamp: submitTimestamp, submitTimestamp, rngTimestamp, mode, rng, userSymbol: guess, actualSymbol: actual, match, username, submitHash, rngHash };
-      const hash = await computeHash({ ...record, timestamp: record.submitTimestamp.toISOString(), rngTimestamp: record.rngTimestamp.toISOString() });
+      const record = { timestamp: submitTimestamp, rngTimestamp, mode, rng, userSymbol: guess, actualSymbol: actual, match, username, submitHash, rngHash };
+      const hash = await computeHash({ ...record, timestamp: record.timestamp.toISOString(), rngTimestamp: record.rngTimestamp.toISOString() });
       record.hash = hash;
       addDoc(collection(db, 'qrng_trials'), record)
         .catch(e => console.error(e));
@@ -423,7 +423,7 @@
             rngTs = rdt.toISOString().replace('T', ' ').split('.')[0];
             rngTsHash = await computeHash(rngTs);
           }
-          rows.push([ts, rngTs, e.username || '', e.mode, e.rng || '', e.userSymbol, ts, tsHash, e.actualSymbol, rngTs, rngTsHash, e.match, e.submitHash || '', e.rngHash || '']);
+          rows.push([rngTs, e.username || '', e.mode, e.rng || '', e.userSymbol, ts, tsHash, e.actualSymbol, rngTs, rngTsHash, e.match, e.submitHash || '', e.rngHash || '']);
         }
       }
       const labels = SYMBOLS;
@@ -442,7 +442,7 @@
       });
       const exportUser = document.getElementById('username').value.trim() || 'unidentified';
       let csv='username,'+exportUser+'\n'+
-              'submitTimestamp,rngTimestamp,username,mode,RNG,userSymbol,userTimestamp,userTimestampHash,actualSymbol,actualTimestamp,actualTimestampHash,match,submitHash,rngHash\n'+
+              'rngTimestamp,username,mode,RNG,userSymbol,userTimestamp,userTimestampHash,actualSymbol,actualTimestamp,actualTimestampHash,match,submitHash,rngHash\n'+
               rows.map(r=>r.join(',')).join('\n')+
               '\n\nSymbol,N,Matches,Rate%,CI,p-value,Power\n'+
               stats.map(x=>`${x.s},${x.n},${x.k},${x.rate},${x.ci},${x.pval},${x.power}`).join('\n');


### PR DESCRIPTION
## Summary
- remove deprecated `submitTimestamp` field from trial record
- compute hashes using `timestamp` only
- drop `submitTimestamp` column in CSV export

## Testing
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_e_6855ac1301fc8326b3e7b85ab40d0b6c