### PR TITLE
Fix about modal overflow in Safari

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,6 +37,8 @@
       border: 1px solid #444;
       box-shadow: 0 0 10px rgba(0,0,0,0.5);
       z-index: 1000;
+      max-height: 90vh;
+      overflow-y: auto;
     }
   </style>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>


### PR DESCRIPTION
## Summary
- prevent `about` modal from exceeding viewport height
- allow scroll within modal

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6855b4ed86fc8326b417f056df4272e4