### PR TITLE
Fix typos in about modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -480,7 +480,7 @@
     <p>This is a fun game to test your skills at picking random colors. This application picks random colors using two different modes: a "quantum" random number generator (QRNG) that converts the pixels from your <strong>camera</strong> into bits used to pick colors, and a software based RNG which generates colors from random.event() code. For the QRNG - no information from your camera is being stored, access is only used to create B&amp;W contrast data for random bit selection, and outside of software based bit selection there's no other monitoring or access.</p>
     <p>There are three different game modes available:</p>
     <p><strong>Focus mode</strong> continuously picks colors. Select a RNG then pick a color you think is going to be the highest match at that give time. After clicking 'Start Trial' the Q/RNG will run - change your selection as it goes to try your luck. When you're done 'Stop Trial' to see how you did, and if you'd like even export your results as a CSV.</p>
-    <p><strong>Guesser mode</strong> is as it sounds, the Q/RNG has pick a color - can you guess which one? Select a color and click 'Start Trial' to guess. How's you guessing game?</p>
+     <p><strong>Guesser mode</strong> is as it sounds, the Q/RNG has picked a color - can you guess which one? Select a color and click 'Start Trial' to guess. How's your guessing game?</p>
     <p><strong>Intuition mode</strong> has you select 5 different color picks before the Q/RNG picks its colors. It's like guesser mode but in reverse. How good are you at guessing which colors will be selected?</p>
     <button id="close-about">Close</button>
   </div>


### PR DESCRIPTION
## Summary
- fix typo in Guesser mode description

## Testing
- `npm test` *(fails: missing package.json)*


------
https://chatgpt.com/codex/tasks/task_e_6855b64bacdc8326af2966c6cbe8f99f