### PR TITLE
Switch to light color scheme

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,8 +7,8 @@
   <style>
     body {
       font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-      background: #222 radial-gradient(#333, #111);
-      color: #eee;
+      background: #f7f7f7 radial-gradient(#ffffff, #e0e0e0);
+      color: #111;
       text-align: center;
       padding: 20px;
     }
@@ -35,7 +35,7 @@
     .no-match { color: red; font-weight: bold; }
     .intuition-choice { margin: 5px; }
     #intuition-inputs { margin-top: 10px; }
-    canvas { background: #222; border: 1px solid #444; margin-top: 20px; }
+    canvas { background: #fff; border: 1px solid #ccc; margin-top: 20px; }
     #chart { background: #fff; width: 320px; height: 240px; }
     #live-container {
       position: relative;
@@ -57,15 +57,15 @@
       transform: translate(-50%, -50%);
       background: #fff;
       padding: 20px;
-      border: 1px solid #444;
-      box-shadow: 0 0 10px rgba(0,0,0,0.5);
+      border: 1px solid #ccc;
+      box-shadow: 0 0 10px rgba(0,0,0,0.3);
       z-index: 1000;
       max-height: 90vh;
       overflow-y: auto;
     }
     .color-wheel-svg { width: 120px; height: 120px; touch-action: none; }
-    .color-wheel-svg path { stroke: #222; stroke-width: 1; cursor: pointer; }
-    .color-wheel-svg path.selected { stroke: #fff; stroke-width: 3; }
+    .color-wheel-svg path { stroke: #555; stroke-width: 1; cursor: pointer; }
+    .color-wheel-svg path.selected { stroke: #000; stroke-width: 3; }
     .color-wheel { display: inline-block; margin: 5px; }
     .color-wheel.disabled { opacity: 0.5; pointer-events: none; }
     .wheel-label { fill: #000; font-size: 10px; pointer-events: none; font-weight: bold; }
@@ -79,7 +79,7 @@
       height: 0;
       border-left: 8px solid transparent;
       border-right: 8px solid transparent;
-      border-bottom: 12px solid #fff;
+      border-bottom: 12px solid #000;
       pointer-events: none;
     }
     .color-wheel-svg.rotatable {


### PR DESCRIPTION
## Summary
- use a light background and dark text
- lighten canvas and color wheel styles
- soften modal border and shadow

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685be5b2046c8326b6395dc0507bcd96