### PR TITLE
Fix wheel label centering

### DIFF
--- a/applet.js
+++ b/applet.js
@@ -98,10 +98,10 @@ async function runGameLogic(){
         <path d="M50,50 L100,50 A50,50 0 0,1 50,100 z" fill="blue" data-color="Blue"></path>
         <path d="M50,50 L50,100 A50,50 0 0,1 0,50 z" fill="green" data-color="Green"></path>
         <path d="M50,50 L0,50 A50,50 0 0,1 50,0 z" fill="yellow" data-color="Yellow"></path>
-        <text x="75" y="25" class="wheel-label">R</text>
-        <text x="75" y="75" class="wheel-label">B</text>
-        <text x="25" y="75" class="wheel-label">G</text>
-        <text x="25" y="25" class="wheel-label">Y</text>
+        <text x="75" y="25" class="wheel-label" text-anchor="middle" dominant-baseline="middle">R</text>
+        <text x="75" y="75" class="wheel-label" text-anchor="middle" dominant-baseline="middle">B</text>
+        <text x="25" y="75" class="wheel-label" text-anchor="middle" dominant-baseline="middle">G</text>
+        <text x="25" y="25" class="wheel-label" text-anchor="middle" dominant-baseline="middle">Y</text>
       </svg>
     </div>`;
   const wheelHandlers={};

--- a/index.html
+++ b/index.html
@@ -68,7 +68,14 @@
     .color-wheel-svg path.selected { stroke: #fff; stroke-width: 3; }
     .color-wheel { display: inline-block; margin: 5px; }
     .color-wheel.disabled { opacity: 0.5; pointer-events: none; }
-    .wheel-label { fill: #000; font-size: 10px; pointer-events: none; font-weight: bold; }
+    .wheel-label {
+      fill: #000;
+      font-size: 14px;
+      pointer-events: none;
+      font-weight: bold;
+      text-anchor: middle;
+      dominant-baseline: middle;
+    }
     .color-wheel-container { position: relative; display: inline-block; }
     .wheel-arrow {
       position: absolute;


### PR DESCRIPTION
## Summary
- center the R/B/G/Y text inside the color wheel quadrants
- enlarge the letters for better readability

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685be73a65848326ab5c6693dd536ec3