### PR TITLE
Add historical analysis dashboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,6 +93,10 @@
       transition: transform 0.2s ease;
       transform-origin: 50% 50%;
     }
+    #analysis-container { margin-top: 30px; }
+    #analysis-options { display: flex; justify-content: center; align-items: center; gap: 10px; flex-wrap: wrap; margin-top: 10px; }
+    #analysis-stats { margin-top: 10px; font-size: 14px; }
+    #analysis-chart { background: #fff; width: 320px; height: 240px; }
   </style>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jstat/1.9.4/jstat.min.js"></script>


### PR DESCRIPTION
## Summary
- add styling for new historical analysis dashboard
- add new dashboard markup with filtering options
- implement functions to load data from Firestore, filter by date/mode/RNG/user
- compute statistical analysis and display bar chart using Chart.js
- initialize dashboard on page load

## Testing
- `node --check applet.js`

------
https://chatgpt.com/codex/tasks/task_e_685c098b376c8326aed534cc5cc75ae6