### PR TITLE
Improve dashboard user filtering

### DIFF
--- a/applet.js
+++ b/applet.js
@@ -81,7 +81,8 @@ export function initGame(container){
         <option value="Camera">Camera</option>
         <option value="Software">Software</option>
       </select>
-      <input type="text" id="filter-user" placeholder="User" />
+      <input list="user-directory" type="text" id="filter-user" placeholder="User" />
+      <datalist id="user-directory"></datalist>
       <button id="analysis-refresh">Refresh</button>
     </div>
     <div id="analysis-stats"></div>
@@ -304,6 +305,9 @@ async function runGameLogic(){
   async function loadAllTrials(){
     const snap=await getDocs(collection(db,'qrng_trials'));
     allTrials=snap.docs.map(d=>d.data());
+    const users=new Set(allTrials.map(e=>(e.username||'').trim()).filter(Boolean));
+    const list=document.getElementById('user-directory');
+    if(list) list.innerHTML=Array.from(users).sort().map(u=>`<option value="${u}">`).join('');
     updateAnalysis();
   }
 


### PR DESCRIPTION
## Summary
- enhance analysis dashboard with searchable user directory

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685c1304aa1c8326a164d7cc90d61d7e