### PR TITLE
Split into separate pages

### DIFF
--- a/analysis.html
+++ b/analysis.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Color Picking Guessing Game</title>
+  <title>Historical Analysis</title>
   <style>
     body {
       font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
@@ -97,8 +97,17 @@
     #menu-items { display:none; list-style:none; padding:5px; margin:0; background:#fff; border:1px solid #ccc; }
     #menu.expanded #menu-items { display:block; }
     #menu-items li { margin:5px 0; }
-    /* hide analysis on home page */
-    #analysis-container { display:none; }
+    /* hide game interface on analysis page */
+    #options-row,
+    #intuition-inputs,
+    #intuition-submit,
+    #trial-button,
+    button[onclick="exportCSV()"],
+    button[onclick="resetPage()"],
+    #about-button,
+    #result,
+    #live-container,
+    #canvas { display:none; }
   </style>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jstat/1.9.4/jstat.min.js"></script>

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>User Leaderboard</title>
+  <style>
+    body {
+      font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+      background: #f7f7f7 radial-gradient(#ffffff, #e0e0e0);
+      color: #111;
+      text-align: center;
+      padding: 20px;
+    }
+    #menu { position: fixed; top: 10px; left: 10px; }
+    #menu-items { display:none; list-style:none; padding:5px; margin:0; background:#fff; border:1px solid #ccc; }
+    #menu.expanded #menu-items { display:block; }
+    #menu-items li { margin:5px 0; }
+  </style>
+  <script type="module" src="leaderboard.js"></script>
+</head>
+<body>
+  <nav id="menu">
+    <button id="menu-toggle">Menu</button>
+    <ul id="menu-items">
+      <li><a href="index.html">Home</a></li>
+      <li><a href="analysis.html">Analysis</a></li>
+      <li><a href="leaderboard.html">Leaderboard</a></li>
+    </ul>
+  </nav>
+  <div id="leaderboard-root">Loading...</div>
+  <script>
+    document.getElementById('menu-toggle').addEventListener('click', () => {
+      document.getElementById('menu').classList.toggle('expanded');
+    });
+  </script>
+</body>
+</html>

--- a/leaderboard.js
+++ b/leaderboard.js
@@ -1,0 +1,34 @@
+export async function initLeaderboard(root){
+  const { initializeApp } = await import('https://www.gstatic.com/firebasejs/9.23.0/firebase-app.js');
+  const { getFirestore, collection, getDocs } = await import('https://www.gstatic.com/firebasejs/9.23.0/firebase-firestore.js');
+  const firebaseConfig = {
+    apiKey: "AIzaSyBQgVavR044F95yG6ETansdwJzer097nqo",
+    authDomain: "colorguesser-50a43.firebaseapp.com",
+    projectId: "colorguesser-50a43",
+    storageBucket: "colorguesser-50a43.firebasestorage.app",
+    messagingSenderId: "154711693442",
+    appId: "1:154711693442:web:064528ee7d86b7e64dbc9b",
+    measurementId: "G-VC3V8WYD0K",
+    databaseURL: "https://colorguesser-50a43-default-rtdb.firebaseio.com/"
+  };
+  const app = initializeApp(firebaseConfig);
+  const db = getFirestore(app);
+  const snap = await getDocs(collection(db,'qrng_trials'));
+  const stats = {};
+  snap.forEach(d => {
+    const e = d.data();
+    const u = (e.username || '').trim();
+    if(!u) return;
+    if(!stats[u]) stats[u] = {matches:0,trials:0};
+    if(e.match) stats[u].matches++;
+    stats[u].trials++;
+  });
+  const entries = Object.entries(stats).map(([user,s]) => ({user, rate:s.trials? s.matches/s.trials:0, trials:s.trials}));
+  entries.sort((a,b)=> b.rate - a.rate || b.trials - a.trials);
+  const top = entries.slice(0,50);
+  root.innerHTML = '<h1>User Leaderboard</h1>'+
+    '<ol>' + top.map(e=>`<li>${e.user} - ${(e.rate*100).toFixed(1)}% (${e.trials})</li>`).join('') + '</ol>';
+}
+
+const container = document.getElementById('leaderboard-root');
+if(container) initLeaderboard(container);


### PR DESCRIPTION
## Summary
- add expandable navigation menu
- split existing single page into index, analysis, and leaderboard pages
- hide elements with page specific CSS rules
- implement leaderboard loader

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68608c16845883268f2fed23ff8bfa61