### PR TITLE
Fix leaderboard not loading

### DIFF
--- a/leaderboard.html
+++ b/leaderboard.html
@@ -29,7 +29,6 @@
     #menu.expanded #menu-items { display:block; }
     #menu-items li { margin:5px 0; }
   </style>
-  <script type="module" src="leaderboard.js"></script>
 </head>
 <body>
   <nav id="menu">
@@ -41,6 +40,7 @@
     </ul>
   </nav>
   <div id="leaderboard-root">Loading...</div>
+  <script type="module" src="leaderboard.js"></script>
   <script>
     document.getElementById('menu-toggle').addEventListener('click', () => {
       document.getElementById('menu').classList.toggle('expanded');


### PR DESCRIPTION
## Summary
- move leaderboard.js to after the leaderboard container so initialization happens after the element exists

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68609393811c8326a304bfc2bbeaac76