### PR TITLE
Ensure leaderboard uses local data when remote fetch returns no results

### DIFF
--- a/leaderboard.js
+++ b/leaderboard.js
@@ -18,6 +18,13 @@ export async function initLeaderboard(root){
     const db = getFirestore(app);
     const snap = await getDocs(collection(db,'qrng_trials'));
     records = snap.docs.map(d=>d.data());
+    if(!records.length){
+      const local = JSON.parse(localStorage.getItem('qrng_trials') || '[]');
+      if(local.length){
+        records = local;
+        loadError = 'Remote database had no data, using local results.';
+      }
+    }
   }catch(e){
     loadError = 'Unable to load online leaderboard data.';
     console.error('Failed loading Firestore data, falling back to localStorage', e);


### PR DESCRIPTION
## Summary
- improve leaderboard reliability when Firestore returns an empty result set

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6860a997d12c8326a4fbb7d341407e2a