### PR TITLE
Add vibration feedback for matches

### DIFF
--- a/applet.js
+++ b/applet.js
@@ -622,6 +622,9 @@ async function runGameLogic(){
       `Your guess: <b>${guess}</b><br>`+
       `Actual: <b>${actual}</b><br>`+
       `<span class='${match?'match':'no-match'}'>${match?'✔ Match!':'✘ No match'}</span>`;
+    if(match && (mode==='guesser' || mode==='blackwhite') && navigator.vibrate){
+      navigator.vibrate(200);
+    }
     const record={timestamp:submitTimestamp,rngTimestamp,mode,rng,userSymbol:guess,actualSymbol:actual,match,username};
     const rngHash=await computeHash({timestamp:rngTimestamp.toISOString(),mode,rng,actualSymbol:actual});
     record.rngHash=rngHash;


### PR DESCRIPTION
## Summary
- provide haptic feedback in guesser and blackwhite modes when there's a match

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6860aaabff2c8326a7c554d65c5e1a52