### PR TITLE
Add sort dropdown to leaderboard

### DIFF
--- a/leaderboard.html
+++ b/leaderboard.html
@@ -54,6 +54,12 @@
       <option value="intuition">Intuition</option>
       <option value="blackwhite">BlackWhite</option>
     </select>
+    <label for="sort-select">Sort By:</label>
+    <select id="sort-select">
+      <option value="mode">Mode</option>
+      <option value="rate" selected>Match Rate</option>
+      <option value="trials">Trials</option>
+    </select>
   </div>
   <div id="leaderboard-root">
     <table id="leaderboard-table">

--- a/leaderboard.js
+++ b/leaderboard.js
@@ -56,6 +56,7 @@ export async function initLeaderboard(root){
   let sortKey = 'rate';
   let sortDir = 'desc';
   const modeFilter = document.getElementById('mode-filter');
+  const sortSelect = document.getElementById('sort-select');
   const tableBody = document.querySelector('#leaderboard-table tbody');
   const headers = document.querySelectorAll('#leaderboard-table th');
 
@@ -82,10 +83,20 @@ export async function initLeaderboard(root){
     }else{
       sortKey = key;
       sortDir = key==='user' || key==='mode' ? 'asc' : 'desc';
+      if(sortSelect) sortSelect.value = key;
     }
     render();
   }));
   modeFilter.addEventListener('change',render);
+  if(sortSelect){
+    sortKey = sortSelect.value || 'rate';
+    sortDir = sortKey==='user' || sortKey==='mode' ? 'asc' : 'desc';
+    sortSelect.addEventListener('change',()=>{
+      sortKey = sortSelect.value;
+      sortDir = sortKey==='user' || sortKey==='mode' ? 'asc' : 'desc';
+      render();
+    });
+  }
   render();
 }
 


### PR DESCRIPTION
## Summary
- add a new Sort By selector to leaderboard.html
- drive sorting from the new selector in leaderboard.js

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686160f307b0832681db070149c456db