### PR TITLE
Fix RNG start in guesser mode

### DIFF
--- a/applet.js
+++ b/applet.js
@@ -401,7 +401,12 @@ async function runGameLogic(){
     setupSlider('single-choice');
     if(m==='intuition') resetIntuitionChoices();
     if(m==='guesser') {
-      startCamera().then(ok=>{ if(ok) ensureNextRng(); });
+      const rng=document.getElementById('rng').value;
+      if(rng==='camera') {
+        startCamera().then(ok=>{ if(ok) ensureNextRng(); });
+      } else {
+        ensureNextRng();
+      }
     } else {
       stopCamera();
     }


### PR DESCRIPTION
## Summary
- ensure event RNG works without webcam by preparing a symbol when in guesser mode

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_68617131f9948326bf5fe2b230a663c2