### PR TITLE
Add fetch error handling

### DIFF
--- a/classic.html
+++ b/classic.html
@@ -23,6 +23,12 @@
   <script>
     (async function(){
       const resp = await fetch('ColorGuessApplet.jar.base64');
+      if (!resp.ok) {
+        const msg = `Failed to load applet archive: ${resp.status} ${resp.statusText}`;
+        alert(msg);
+        console.error(msg);
+        return;
+      }
       const b64 = (await resp.text()).trim();
       const bytes = Uint8Array.from(atob(b64), c => c.charCodeAt(0));
       const url = URL.createObjectURL(new Blob([bytes], {type: 'application/java-archive'}));


### PR DESCRIPTION
## Summary
- alert the user when `ColorGuessApplet.jar.base64` cannot be fetched

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68711f4cd4c0832681f58a417a0824d1