### PR TITLE
Add network error handling for applet fetch

### DIFF
--- a/classic.html
+++ b/classic.html
@@ -22,7 +22,15 @@
   </div>
   <script>
     (async function(){
-      const resp = await fetch('ColorGuessApplet.jar.base64');
+      let resp;
+      try {
+        resp = await fetch('ColorGuessApplet.jar.base64');
+      } catch (err) {
+        const msg = `Error fetching applet archive: ${err}`;
+        alert(msg);
+        console.error(msg);
+        return;
+      }
       if (!resp.ok) {
         const msg = `Failed to load applet archive: ${resp.status} ${resp.statusText}`;
         alert(msg);


### PR DESCRIPTION
## Summary
- handle errors when fetching the Java applet in `classic.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68714a3a7fe08326996fa9fc7a6070ec