### PR TITLE
Ensure relaxing music loops

### DIFF
--- a/applet.js
+++ b/applet.js
@@ -778,10 +778,18 @@ async function runGameLogic(){
   function startRelax(){
     cycleCount=1;
     document.getElementById('relax-cycle').textContent=`${cycleCount}/10`;
+    const audio=document.getElementById('relax-audio');
+    audio.loop=true;
+    audio.play();
     startRelaxCycle();
   }
 
   function startRelaxCycle(){
+    const audio=document.getElementById('relax-audio');
+    audio.loop=true;
+    if(audio.paused){
+      audio.play();
+    }
     const nextBtn=document.getElementById('next-cycle');
     nextBtn.disabled=true;
     nextBtn.classList.remove('highlight');


### PR DESCRIPTION
## Summary
- auto-play relaxing music when entering the relax mode
- keep audio playing for each cycle

## Testing
- `node --check applet.js`


------
https://chatgpt.com/codex/tasks/task_e_6871ba1f340c8326aa76016a5746c18e