### PR TITLE
Mute relax music by default

### DIFF
--- a/applet.js
+++ b/applet.js
@@ -780,16 +780,12 @@ async function runGameLogic(){
     document.getElementById('relax-cycle').textContent=`${cycleCount}/10`;
     const audio=document.getElementById('relax-audio');
     audio.loop=true;
-    audio.play();
     startRelaxCycle();
   }
 
   function startRelaxCycle(){
     const audio=document.getElementById('relax-audio');
     audio.loop=true;
-    if(audio.paused){
-      audio.play();
-    }
     const nextBtn=document.getElementById('next-cycle');
     nextBtn.disabled=true;
     nextBtn.classList.remove('highlight');


### PR DESCRIPTION
## Summary
- relax mode started music automatically
- keep music muted unless the user taps the Music button

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_687234e1066c83268e881fc672e33600