### PR TITLE
Add Relax Guesser menu link

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,6 +148,7 @@
       <li><a href="index.html">Home</a></li>
       <li><a href="analysis.html">Analysis</a></li>
       <li><a href="leaderboard.html">Leaderboard</a></li>
+      <li><a href="relaxguesser.html">Relax Guesser</a></li>
     </ul>
   </nav>
   <div id="qrng-game"></div>


### PR DESCRIPTION
## Summary
- add missing Relax Guesser entry in the homepage menu

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68723fbc3e408326b0f6a3189f6032ec