### PR TITLE
Use camera QRNG with fallback for relaxguesser

### DIFF
--- a/relaxguesser.html
+++ b/relaxguesser.html
@@ -80,9 +80,11 @@
     <div id="relax-circle"></div>
     <div id="relax-countdown">60</div>
     <button id="relax-music">Music</button>
-    <button id="next-cycle" disabled>Next</button>
-    <audio id="relax-audio" src="relax.mp3" loop></audio>
-  </div>
+  <button id="next-cycle" disabled>Next</button>
+  <audio id="relax-audio" src="relax.mp3" loop></audio>
+  <video id="video" width="320" height="240" autoplay muted style="display:none"></video>
+  <canvas id="canvas" width="320" height="240" style="display:none"></canvas>
+</div>
 
   <h2 id="status">Trial 1 of 24</h2>
   <div id="color-boxes">
@@ -98,6 +100,85 @@
     const colors = ['Red','Blue','Green','Yellow'];
     let trial = 0;
     let audioCtx = null;
+    const video = document.getElementById('video');
+    const canvas = document.getElementById('canvas');
+    const ctx = canvas.getContext('2d');
+    let cameraStream = null;
+    let useCamera = false;
+
+    async function startCamera(){
+      if(cameraStream || !navigator.mediaDevices?.getUserMedia) return cameraStream;
+      try{
+        cameraStream = await navigator.mediaDevices.getUserMedia({ video: true });
+        video.srcObject = cameraStream;
+        await new Promise(res => video.addEventListener('playing', res, { once: true }));
+        return cameraStream;
+      }catch(e){
+        console.warn('Camera unavailable', e);
+        cameraStream = null;
+        return null;
+      }
+    }
+
+    function stopCamera(){
+      if(cameraStream){
+        cameraStream.getTracks().forEach(t=>t.stop());
+        cameraStream = null;
+        video.srcObject = null;
+      }
+    }
+
+    function extractRawBits(data,w,h){
+      const bits=[];
+      for(let i=0;i<64;i++){
+        const x1=Math.floor(Math.random()*w), y1=Math.floor(Math.random()*h);
+        const x2=Math.floor(Math.random()*w), y2=Math.floor(Math.random()*h);
+        const idx1=(y1*w+x1)*4, idx2=(y2*w+x2)*4;
+        const g1=0.299*data[idx1]+0.587*data[idx1+1]+0.114*data[idx1+2];
+        const g2=0.299*data[idx2]+0.587*data[idx2+1]+0.114*data[idx2+2];
+        bits.push((g1^g2)&1);
+      }
+      return bits;
+    }
+
+    function vonNeumann(bits){
+      const out=[];
+      for(let i=0;i<bits.length-1;i+=2){
+        const [b1,b2]=[bits[i],bits[i+1]];
+        if(b1===0 && b2===1) out.push(0);
+        else if(b1===1 && b2===0) out.push(1);
+      }
+      return out;
+    }
+
+    function getSymbolFromCamera(){
+      if(!cameraStream) return null;
+      ctx.drawImage(video,0,0,canvas.width,canvas.height);
+      const raw=extractRawBits(ctx.getImageData(0,0,canvas.width,canvas.height).data,canvas.width,canvas.height);
+      const vn=vonNeumann(raw);
+      if(vn.length<2) return null;
+      return colors[parseInt(vn.slice(0,2).join(''),2)%colors.length];
+    }
+
+    function getSymbolFromEvent(){
+      const arr=new Uint32Array(1);
+      window.crypto.getRandomValues(arr);
+      return colors[arr[0]%colors.length];
+    }
+
+    function getSymbol(){
+      if(useCamera){
+        const s=getSymbolFromCamera();
+        if(s) return s;
+      }
+      return getSymbolFromEvent();
+    }
+
+    async function checkCamera(){
+      const cam=await startCamera();
+      useCamera=!!cam;
+      if(!useCamera) stopCamera();
+    }
 
     function playTone(match){
       try{
@@ -116,10 +197,11 @@
       }
     }
 
-    function handleGuess(e){
+    async function handleGuess(e){
       if(trial >= TOTAL_TRIALS) return;
+      if(trial === 0) await checkCamera();
       const guess = e.currentTarget.getAttribute('data-color');
-      const actual = colors[Math.floor(Math.random()*colors.length)];
+      const actual = getSymbol();
       const match = guess === actual;
       const li = document.createElement('li');
       li.textContent = `Trial ${trial+1}: guessed ${guess}, actual ${actual} - ${match? 'Match' : 'No match'}`;
@@ -207,7 +289,7 @@
       }
       localStorage.setItem('relax_music_playing',relaxMusicPlaying?'1':'0');
     });
-    startRelax();
+    checkCamera().finally(startRelax);
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add hidden video/canvas for camera RNG
- default to camera RNG with automatic fallback to software RNG
- check camera availability on load and before the first trial

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687240ec0d8083269d7eab68f843ce1b