### PR TITLE
Fix camera start check for older browsers

### DIFF
--- a/applet.js
+++ b/applet.js
@@ -453,7 +453,7 @@ async function runGameLogic(){
 
   let cameraStream = null;
   async function startCamera(){
-    if(cameraStream || !navigator.mediaDevices?.getUserMedia) return cameraStream;
+    if(cameraStream || !(navigator.mediaDevices && navigator.mediaDevices.getUserMedia)) return cameraStream;
     try{
       cameraStream = await navigator.mediaDevices.getUserMedia({ video: true });
       video.srcObject = cameraStream;

--- a/relaxguesser.html
+++ b/relaxguesser.html
@@ -107,7 +107,7 @@
     let useCamera = false;
 
     async function startCamera(){
-      if(cameraStream || !navigator.mediaDevices?.getUserMedia) return cameraStream;
+      if(cameraStream || !(navigator.mediaDevices && navigator.mediaDevices.getUserMedia)) return cameraStream;
       try{
         cameraStream = await navigator.mediaDevices.getUserMedia({ video: true });
         video.srcObject = cameraStream;


### PR DESCRIPTION
## Summary
- check for navigator.mediaDevices without using optional chaining to avoid syntax errors in older browsers

## Testing
- `node -c applet.js`


------
https://chatgpt.com/codex/tasks/task_e_68724c78062c8326acc4981a1d95570c