### PR TITLE
Implement Safari browser detection for RNG

### DIFF
--- a/relaxguesser.html
+++ b/relaxguesser.html
@@ -101,6 +101,7 @@
     const colors = ['Red','Blue','Green','Yellow'];
     let trial = 0;
     let audioCtx = null;
+    const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
     const video = document.getElementById('video');
     const canvas = document.getElementById('canvas');
     const ctx = canvas.getContext('2d');
@@ -176,9 +177,15 @@
     }
 
     async function checkCamera(){
+      if(!isSafari){
+        useCamera=false;
+        stopCamera();
+        return null;
+      }
       const cam=await startCamera();
       useCamera=!!cam;
       if(!useCamera) stopCamera();
+      return cam;
     }
 
     function playTone(match){


### PR DESCRIPTION
## Summary
- add Safari browser detection for relaxguesser
- call the camera RNG only on Safari and fall back to crypto RNG otherwise

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687284e983f08326bcc18dbac3fa4a87