### PR TITLE
Add separate mode selection

### DIFF
--- a/applet.js
+++ b/applet.js
@@ -19,15 +19,6 @@ export function initGame(container){
   </div>
   <div id="options-row">
     <div>
-      <label>Select Mode:</label>
-      <select id="mode">
-        <option value="focus">Focus</option>
-        <option value="guesser">Guesser</option>
-        <option value="intuition">Intuition</option>
-        <option value="blackwhite">BlackWhite</option>
-      </select>
-    </div>
-    <div>
       <label>RNG:</label>
       <select id="rng">
         <option value="camera" selected>Camera</option>
@@ -39,6 +30,13 @@ export function initGame(container){
       <input type="hidden" id="single-choice" value="Red" />
       <div class="color-slider" data-input="single-choice"></div>
     </div>
+  </div>
+  <div id="mode-row">
+    <label>Select Mode:</label>
+    <select id="mode">
+      <option value="intuition" selected>Intuition</option>
+      <option value="guesser">Guesser</option>
+    </select>
   </div>
   <div id="intuition-inputs" style="display:none;">
     <label>Select 5 Colors:</label><br>

--- a/index.html
+++ b/index.html
@@ -60,6 +60,7 @@
     #dashboard-stats { position: absolute; top: 5px; right: 5px; background: rgba(255,255,255,0.8); padding: 4px 8px; border-radius: 4px; font-size: 14px; line-height: 1.2; text-align: right; }
     #options-row { display: flex; justify-content: center; align-items: center; gap: 15px; flex-wrap: wrap; }
     #options-row > div { display: flex; align-items: center; gap: 5px; }
+    #mode-row { display: flex; justify-content: center; align-items: center; gap: 5px; margin-top: 10px; }
     #about-modal {
       display: none;
       position: fixed;


### PR DESCRIPTION
## Summary
- move the mode dropdown below the color selector
- reduce available modes to Intuition and Guesser and default to Intuition
- add styling for the new mode row

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6872a29a5ae483269a6adac3fc29510a