### PR TITLE
Fix mode selector placement

### DIFF
--- a/applet.js
+++ b/applet.js
@@ -19,6 +19,15 @@ export function initGame(container){
   </div>
   <div id="options-row">
     <div>
+      <label>Select Mode:</label>
+      <select id="mode">
+        <option value="focus">Focus</option>
+        <option value="guesser">Guesser</option>
+        <option value="intuition">Intuition</option>
+        <option value="blackwhite">BlackWhite</option>
+      </select>
+    </div>
+    <div>
       <label>RNG:</label>
       <select id="rng">
         <option value="camera" selected>Camera</option>
@@ -30,13 +39,6 @@ export function initGame(container){
       <input type="hidden" id="single-choice" value="Red" />
       <div class="color-slider" data-input="single-choice"></div>
     </div>
-  </div>
-  <div id="mode-row">
-    <label>Select Mode:</label>
-    <select id="mode">
-      <option value="intuition" selected>Intuition</option>
-      <option value="guesser">Guesser</option>
-    </select>
   </div>
   <div id="intuition-inputs" style="display:none;">
     <label>Select 5 Colors:</label><br>

--- a/index.html
+++ b/index.html
@@ -60,7 +60,6 @@
     #dashboard-stats { position: absolute; top: 5px; right: 5px; background: rgba(255,255,255,0.8); padding: 4px 8px; border-radius: 4px; font-size: 14px; line-height: 1.2; text-align: right; }
     #options-row { display: flex; justify-content: center; align-items: center; gap: 15px; flex-wrap: wrap; }
     #options-row > div { display: flex; align-items: center; gap: 5px; }
-    #mode-row { display: flex; justify-content: center; align-items: center; gap: 5px; margin-top: 10px; }
     #about-modal {
       display: none;
       position: fixed;

--- a/relaxguesser.html
+++ b/relaxguesser.html
@@ -77,6 +77,7 @@
     #menu-items { display: none; list-style: none; padding: 5px; margin: 0; background: #fff; border: 1px solid #ccc; }
     #menu.expanded #menu-items { display: block; }
     #menu-items li { margin: 5px 0; }
+    #mode-row { display: flex; justify-content: center; align-items: center; gap: 5px; margin-top: 10px; }
   </style>
 </head>
 <body>
@@ -107,6 +108,15 @@
     <div class="color-box blue" data-color="Blue">Blue</div>
     <div class="color-box green" data-color="Green">Green</div>
     <div class="color-box yellow" data-color="Yellow">Yellow</div>
+  </div>
+  <div id="mode-row">
+    <label>Select Mode:</label>
+    <select id="mode">
+      <option value="focus">Focus</option>
+      <option value="guesser">Guesser</option>
+      <option value="intuition">Intuition</option>
+      <option value="blackwhite">BlackWhite</option>
+    </select>
   </div>
   <ol id="history"></ol>
 


### PR DESCRIPTION
## Summary
- restore full mode list in `applet.js`
- remove unused mode row styling from `index.html`
- add mode selector under color buttons in `relaxguesser.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6872b98c2f648326bb4b89f41ee29e69