### PR TITLE
Remove camera RNG from relaxguesser

### DIFF
--- a/relaxguesser.html
+++ b/relaxguesser.html
@@ -98,8 +98,6 @@
     <button id="relax-sound">Sound</button>
   <button id="next-cycle" disabled>Next</button>
   <audio id="relax-audio" src="relax.mp3" loop></audio>
-  <video id="video" width="320" height="240" autoplay muted style="display:none"></video>
-  <canvas id="canvas" width="320" height="240" style="display:none"></canvas>
 </div>
 
   <h2 id="status">Trial 1 of 24</h2>
@@ -126,66 +124,7 @@
     let trial = 0;
     let matchCount = 0;
     let audioCtx = null;
-    const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
-    const video = document.getElementById('video');
-    const canvas = document.getElementById('canvas');
-    const ctx = canvas.getContext('2d');
-    let cameraStream = null;
-    let useCamera = false;
-
-    async function startCamera(){
-      if(cameraStream || !(navigator.mediaDevices && navigator.mediaDevices.getUserMedia)) return cameraStream;
-      try{
-        cameraStream = await navigator.mediaDevices.getUserMedia({ video: true });
-        video.srcObject = cameraStream;
-        await new Promise(res => video.addEventListener('playing', res, { once: true }));
-        return cameraStream;
-      }catch(e){
-        console.warn('Camera unavailable', e);
-        cameraStream = null;
-        return null;
-      }
-    }
-
-    function stopCamera(){
-      if(cameraStream){
-        cameraStream.getTracks().forEach(t=>t.stop());
-        cameraStream = null;
-        video.srcObject = null;
-      }
-    }
-
-    function extractRawBits(data,w,h){
-      const bits=[];
-      for(let i=0;i<64;i++){
-        const x1=Math.floor(Math.random()*w), y1=Math.floor(Math.random()*h);
-        const x2=Math.floor(Math.random()*w), y2=Math.floor(Math.random()*h);
-        const idx1=(y1*w+x1)*4, idx2=(y2*w+x2)*4;
-        const g1=0.299*data[idx1]+0.587*data[idx1+1]+0.114*data[idx1+2];
-        const g2=0.299*data[idx2]+0.587*data[idx2+1]+0.114*data[idx2+2];
-        bits.push((g1^g2)&1);
-      }
-      return bits;
-    }
-
-    function vonNeumann(bits){
-      const out=[];
-      for(let i=0;i<bits.length-1;i+=2){
-        const [b1,b2]=[bits[i],bits[i+1]];
-        if(b1===0 && b2===1) out.push(0);
-        else if(b1===1 && b2===0) out.push(1);
-      }
-      return out;
-    }
-
-    function getSymbolFromCamera(){
-      if(!cameraStream) return null;
-      ctx.drawImage(video,0,0,canvas.width,canvas.height);
-      const raw=extractRawBits(ctx.getImageData(0,0,canvas.width,canvas.height).data,canvas.width,canvas.height);
-      const vn=vonNeumann(raw);
-      if(vn.length<2) return null;
-      return colors[parseInt(vn.slice(0,2).join(''),2)%colors.length];
-    }
+    // Camera-based RNG removed. Symbols are generated using software RNG only.
 
     function getSymbolFromEvent(){
       const arr=new Uint32Array(1);
@@ -194,23 +133,7 @@
     }
 
     function getSymbol(){
-      if(useCamera){
-        const s=getSymbolFromCamera();
-        if(s) return s;
-      }
       return getSymbolFromEvent();
-    }
-
-    async function checkCamera(){
-      if(!isSafari){
-        useCamera=false;
-        stopCamera();
-        return null;
-      }
-      const cam=await startCamera();
-      useCamera=!!cam;
-      if(!useCamera) stopCamera();
-      return cam;
     }
 
     function playTone(match){
@@ -232,7 +155,6 @@
 
     async function handleGuess(e){
       if(trial >= TOTAL_TRIALS) return;
-      if(trial === 0) await checkCamera();
       const guess = e.currentTarget.getAttribute('data-color');
       const actual = getSymbol();
       const match = guess === actual;
@@ -345,7 +267,7 @@
       }
     });
     updateMuteButton();
-    checkCamera().finally(startRelax);
+    startRelax();
   </script>
   <script>
     document.getElementById("menu-toggle").addEventListener("click", () => {


### PR DESCRIPTION
## Summary
- remove camera-based RNG code and markup in `relaxguesser.html`
- rely solely on software RNG

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6872f606a92483268c1c657bc65f8a44