### PR TITLE
Reset relax session when game is reset

### DIFF
--- a/relaxguesser.html
+++ b/relaxguesser.html
@@ -236,6 +236,7 @@
         b.addEventListener('click', handleGuess);
       });
       disableGuesses();
+      resetRelaxDashboard();
     }
 
     document.getElementById('reset-trials').addEventListener('click', resetTrials);
@@ -248,6 +249,18 @@
 
     function updateMuteButton(){
       document.getElementById('relax-music').textContent = relaxMusicPlaying ? 'Mute Off' : 'Mute On';
+    }
+
+    function resetRelaxDashboard(){
+      clearInterval(colorInterval);
+      clearInterval(countdownInterval);
+      const audio=document.getElementById('relax-audio');
+      audio.pause();
+      audio.currentTime=0;
+      document.getElementById('next-cycle').disabled=true;
+      document.getElementById('next-cycle').classList.remove('highlight');
+      cycleCount=0;
+      startRelax();
     }
 
    function startRelax(){


### PR DESCRIPTION
## Summary
- reset trials should also restart the relax dashboard

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68731e63221883269fba2cb0a4ff4427