### PR TITLE
Auto start relax cycles

### DIFF
--- a/relaxguesser.html
+++ b/relaxguesser.html
@@ -109,7 +109,6 @@
     <div id="relax-countdown">24</div>
     <button id="relax-music">Mute Off</button>
     <button id="relax-sound">Sound</button>
-  <button id="next-cycle" disabled>Next</button>
   <audio id="relax-audio" src="relax.mp3" loop></audio>
 </div>
 
@@ -205,10 +204,8 @@
       }
       if(guessesThisCycle >= MAX_GUESSES_PER_CYCLE || trial >= TOTAL_TRIALS){
         disableGuesses();
-        const nextBtn=document.getElementById('next-cycle');
-        if(cycleCount < TOTAL_CYCLES){
-          nextBtn.disabled=false;
-          nextBtn.classList.add('highlight');
+        if(cycleCount < TOTAL_CYCLES && trial < TOTAL_TRIALS){
+          setTimeout(nextCycle, 1000);
         }
       }
     }
@@ -257,8 +254,6 @@
       const audio=document.getElementById('relax-audio');
       audio.pause();
       audio.currentTime=0;
-      document.getElementById('next-cycle').disabled=true;
-      document.getElementById('next-cycle').classList.remove('highlight');
       cycleCount=0;
       startRelax();
     }
@@ -281,9 +276,6 @@
       disableGuesses();
       const audio=document.getElementById('relax-audio');
       audio.loop=true;
-      const nextBtn=document.getElementById('next-cycle');
-      nextBtn.disabled=true;
-      nextBtn.classList.remove('highlight');
       const circle=document.getElementById('relax-circle');
       circle.style.animation='none';
       void circle.offsetWidth;
@@ -306,9 +298,6 @@
     function finishRelaxCycle(){
       clearInterval(colorInterval);
       clearInterval(countdownInterval);
-      const nextBtn=document.getElementById('next-cycle');
-      nextBtn.disabled=true;
-      nextBtn.classList.remove('highlight');
       enableGuesses();
     }
 
@@ -319,7 +308,6 @@
       startRelaxCycle();
     }
 
-    document.getElementById('next-cycle').addEventListener('click',nextCycle);
     document.getElementById('relax-music').addEventListener('click',()=>{
       const audio=document.getElementById('relax-audio');
       if(audio.paused){


### PR DESCRIPTION
## Summary
- remove Next button from Relax Guesser page
- start next relax cycle automatically after guesses

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68739c5cb6388326b840260e1dcb5bef