### PR TITLE
Update puzzle drop logic and visuals

### DIFF
--- a/betaguesser.html
+++ b/betaguesser.html
@@ -48,6 +48,7 @@
       height: 20px;
       box-sizing:border-box;
       border:1px solid #222;
+      border-radius:50%;
     }
     .filled { background:#666; }
     .piece { background:#ff6666; }
@@ -246,7 +247,9 @@
 
     // Tetris puzzle implementation
     const ROWS=20, COLS=10;
-    let board=[], piece=[], pieceRow=0, pieceCol=0, dropInterval;
+    const INITIAL_SHAPES = 15;
+    const PIECES_PER_ROUND = 10;
+    let board=[], piece=[], pieceRow=0, pieceCol=0, dropInterval, piecesDropped=0;
     const shapes=[
       [[0,1,0],[1,1,1]], // T
       [[1,1,1,1]],       // I
@@ -259,6 +262,22 @@
 
     function createBoard(){
       board = Array.from({length:ROWS},()=>Array(COLS).fill(0));
+    }
+
+    function placeInitialShapes(count){
+      for(let i=0;i<count;i++){
+        let mat = JSON.parse(JSON.stringify(shapes[Math.floor(Math.random()*shapes.length)]));
+        const rotations=Math.floor(Math.random()*4);
+        for(let r=0;r<rotations;r++) mat=rotate(mat);
+        let col=Math.floor(Math.random()*(COLS-mat[0].length+1));
+        let row=0;
+        while(valid(row+1,col,mat)) row++;
+        for(let r=0;r<mat.length;r++){
+          for(let c=0;c<mat[r].length;c++){
+            if(mat[r][c]) board[row+r][col+c]=1;
+          }
+        }
+      }
     }
 
     function rotate(mat){
@@ -323,8 +342,15 @@
           if(piece[r][c]) board[pieceRow+r][pieceCol+c]=1;
         }
       }
+      piecesDropped++;
       clearInterval(dropInterval);
-      puzzleComplete();
+      if(piecesDropped>=PIECES_PER_ROUND){
+        puzzleComplete();
+      }else{
+        spawnPiece();
+        draw();
+        dropInterval=setInterval(drop,250);
+      }
     }
 
     function puzzleComplete(){
@@ -335,9 +361,11 @@
     function startPuzzle(){
       document.getElementById('puzzle-status').textContent='Solve the puzzle';
       createBoard();
+      placeInitialShapes(INITIAL_SHAPES);
+      piecesDropped=0;
       spawnPiece();
       draw();
-      dropInterval=setInterval(drop,500);
+      dropInterval=setInterval(drop,250);
     }
 
     document.addEventListener('keydown',e=>{


### PR DESCRIPTION
## Summary
- use circles for Tetris board cells
- place 15 random shapes before the puzzle begins
- drop pieces faster and drop a total of 10 per round

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687855b2a4c483269051435c1cf54cda