### PR TITLE
Add auto-solve for tetris when board empty

### DIFF
--- a/betaguesser.html
+++ b/betaguesser.html
@@ -323,6 +323,15 @@
       }
     }
 
+    function boardIsEmpty(){
+      for(let r=0;r<ROWS;r++){
+        for(let c=0;c<COLS;c++){
+          if(board[r][c]) return false;
+        }
+      }
+      return true;
+    }
+
     function draw(){
       const container=document.getElementById('tetris');
       container.innerHTML='';
@@ -370,6 +379,10 @@
         }
       }
       clearLines();
+      if(boardIsEmpty()){
+        puzzleComplete();
+        return;
+      }
       piecesDropped++;
       clearInterval(dropInterval);
       if(board[0].some(v=>v)){


### PR DESCRIPTION
## Summary
- add `boardIsEmpty()` helper
- end tetris portion early if the board is cleared

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6878600cb2c4832692831d86d93e43c9