### PR TITLE
Add hybridguesser combining puzzle and relax

### DIFF
--- a/hybridguesser.html
+++ b/hybridguesser.html
@@ -1,0 +1,651 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Hybrid Guesser</title>
+  <style>
+    body {
+      font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+      background: #f7f7f7 radial-gradient(#ffffff, #e0e0e0);
+      color: #111;
+      text-align: center;
+      padding: 20px;
+    }
+    button {
+      padding: 10px 20px;
+      margin: 10px;
+      font-size: 16px;
+      color: #fff;
+      background: linear-gradient(45deg, #0066ff, #00ccff);
+      border: none;
+      border-radius: 8px;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.3);
+      cursor: pointer;
+    }
+    button:hover { opacity: 0.9; }
+    #puzzle-container {
+      display: block;
+      margin: 0 auto 20px;
+      background: #fff;
+      padding: 20px;
+      border: 1px solid #ccc;
+      box-shadow: 0 0 10px rgba(0,0,0,0.3);
+      text-align: center;
+    }
+    #tetris {
+      width: 200px;
+      height: 400px;
+      margin: 10px auto;
+      display: grid;
+      grid-template-columns: repeat(10,20px);
+      grid-template-rows: repeat(20,20px);
+      background:#000;
+      border:2px solid #333;
+    }
+    .cell {
+      width: 20px;
+      height: 20px;
+      box-sizing:border-box;
+      border:1px solid #222;
+      border-radius:50%;
+    }
+    .filled { background:#666; }
+    .piece { background:#ff6666; }
+    #relax-modal {
+      display: none;
+      margin: 0 auto 20px;
+      background: #fff;
+      padding: 20px;
+      border: 1px solid #ccc;
+      box-shadow: 0 0 10px rgba(0,0,0,0.3);
+      text-align: center;
+    }
+    #relax-circle {
+      position: relative;
+      width: 200px;
+      height: 200px;
+      margin: 20px auto;
+      border-radius: 50%;
+      background: #f8c8dc;
+      animation: grow-shrink 12s linear 2 forwards;
+      transition: background-color 2s linear;
+    }
+    #focus-point {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      width: 12px;
+      height: 12px;
+      margin: -6px 0 0 -6px;
+      border-radius: 50%;
+      background: #555;
+      pointer-events: none;
+    }
+    @keyframes grow-shrink {
+      0% { transform: scale(0); }
+      50% { transform: scale(1); }
+      100% { transform: scale(0); }
+    }
+    #color-section { display:none; }
+    #color-boxes {
+      display: flex;
+      justify-content: center;
+      gap: 20px;
+      margin-top: 20px;
+    }
+    .color-box {
+      width: 100px;
+      height: 100px;
+      border-radius: 8px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-weight: bold;
+      color: #fff;
+      cursor: pointer;
+      user-select: none;
+      font-size: 18px;
+    }
+    .color-box.disabled{opacity:0.6;pointer-events:none;}
+    .red { background: red; }
+    .blue { background: blue; }
+    .green { background: green; }
+    .yellow { background: yellow; color: #000; }
+    #history { list-style: none; padding: 0; margin-top: 20px; }
+    #menu { position: fixed; top: 10px; left: 10px; }
+    #menu-items { display:none; list-style:none; padding:5px; margin:0; background:#fff; border:1px solid #ccc; }
+    #menu.expanded #menu-items { display:block; }
+    #menu-items li { margin:5px 0; }
+    #mode-row { display: flex; justify-content: center; align-items: center; gap:5px; margin-top:10px; }
+    #reset-modal {
+      display: none;
+      position: fixed;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      background: #fff;
+      padding: 20px;
+      border: 1px solid #ccc;
+      box-shadow: 0 0 10px rgba(0,0,0,0.3);
+      z-index: 1000;
+    }
+  </style>
+</head>
+<body>
+  <nav id="menu">
+    <button id="menu-toggle">Menu</button>
+    <ul id="menu-items">
+      <li><a href="index.html">Home</a></li>
+      <li><a href="analysis.html">Analysis</a></li>
+      <li><a href="leaderboard.html">Leaderboard</a></li>
+      <li><a href="relaxguesser.html">Relax Guesser</a></li>
+      <li><a href="betaguesser.html">Beta Guesser</a></li>
+    </ul>
+  </nav>
+  <div id="puzzle-container">
+    <div id="puzzle-status">Solve the puzzle</div>
+    <div id="tetris"></div>
+    <button id="puzzle-music">Mute Off</button>
+    <button id="puzzle-sound">Sound</button>
+    <audio id="puzzle-audio" src="relax.mp3" loop></audio>
+  </div>
+  <div id="relax-modal">
+    <div id="relax-cycle">0/6</div>
+    <div id="relax-circle"><div id="focus-point"></div></div>
+    <div id="relax-countdown">24</div>
+    <button id="relax-music">Mute Off</button>
+    <button id="relax-sound">Sound</button>
+    <audio id="relax-audio" src="relax.mp3" loop></audio>
+  </div>
+  <div id="color-section">
+    <h2 id="status">Trial 1 of 24</h2>
+    <div id="color-boxes">
+      <div class="color-box red" data-color="Red">Red</div>
+      <div class="color-box blue" data-color="Blue">Blue</div>
+      <div class="color-box green" data-color="Green">Green</div>
+      <div class="color-box yellow" data-color="Yellow">Yellow</div>
+    </div>
+    <div id="mode-row">
+      <label>Select Mode:</label>
+      <select id="mode">
+        <option value="intuition" selected>Intuition</option>
+        <option value="guesser">Guesser</option>
+      </select>
+      <button id="reset-trials">Reset</button>
+    </div>
+    <ol id="history"></ol>
+  </div>
+  <div id="reset-modal">
+    <p>Are you sure you'd like to reset?</p>
+    <button id="reset-yes">Yes</button>
+    <button id="reset-no">No</button>
+  </div>
+
+  <script>
+    const TOTAL_TRIALS = 24;
+    const TRIALS_PER_ROUND = 4;
+    const TOTAL_CYCLES = 6;
+    const colors = ['Red','Blue','Green','Yellow'];
+    let trial = 0;
+    let matchCount = 0;
+    let audioCtx = null;
+    let guessEnabled = false;
+    let trialsThisRound = 0;
+    let cycleCount = 0;
+
+    function getSymbolFromEvent(){
+      const arr=new Uint32Array(1);
+      window.crypto.getRandomValues(arr);
+      return colors[arr[0]%colors.length];
+    }
+
+    function getSymbol(){
+      return getSymbolFromEvent();
+    }
+
+    function playTone(match){
+      try{
+        if(!audioCtx) audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+        const osc = audioCtx.createOscillator();
+        const gain = audioCtx.createGain();
+        osc.connect(gain);
+        gain.connect(audioCtx.destination);
+        osc.frequency.value = match ? 880 : 440;
+        osc.type = 'sine';
+        gain.gain.value = 0.5;
+        osc.start();
+        osc.stop(audioCtx.currentTime + 0.2);
+      }catch(e){
+        console.error('tone error', e);
+      }
+    }
+
+    function handleGuess(e){
+      if(!guessEnabled || trial >= TOTAL_TRIALS) return;
+      const guess = e.currentTarget.getAttribute('data-color');
+      const actual = getSymbol();
+      const match = guess === actual;
+      const li = document.createElement('li');
+      li.textContent = `Trial ${trial+1}: guessed ${guess}, actual ${actual} - ${match? 'Match' : 'No match'}`;
+      if(match) matchCount++;
+      document.getElementById('history').prepend(li);
+      playTone(match);
+      trial++;
+      trialsThisRound++;
+      if(trial >= TOTAL_TRIALS){
+        const matchRate = ((matchCount / TOTAL_TRIALS) * 100).toFixed(1);
+        let prefix;
+        if(matchCount <= 6){
+          prefix = 'You did great, try another session and go again.';
+        }else if(matchCount <= 9){
+          prefix = "Excellent work! You're getting better, try again?";
+        }else if(matchCount <= 13){
+          prefix = 'Amazing!';
+        }else if(matchCount <= 16){
+          prefix = 'Incredible intuition!';
+        }else if(matchCount <= 20){
+          prefix = 'Astounding!';
+        }else{
+          prefix = 'Otherworldly!';
+        }
+        document.getElementById('status').textContent = `${prefix} ${matchCount}/${TOTAL_TRIALS} matched (${matchRate}%)`;
+        document.querySelectorAll('.color-box').forEach(b=>b.removeEventListener('click', handleGuess));
+      } else if(trialsThisRound >= TRIALS_PER_ROUND){
+        trialsThisRound = 0;
+        disableGuesses();
+        document.getElementById('status').textContent = 'Solve the puzzle to continue';
+        setTimeout(startGameCycle, 1000);
+      } else {
+        document.getElementById('status').textContent = `Trial ${trial+1} of ${TOTAL_TRIALS}`;
+      }
+    }
+
+    document.querySelectorAll('.color-box').forEach(b=>b.addEventListener('click', handleGuess));
+
+    function enableGuesses(){
+      guessEnabled=true;
+      document.querySelectorAll('.color-box').forEach(b=>b.classList.remove('disabled'));
+      document.getElementById('color-section').style.display='block';
+      document.getElementById('status').textContent = `Trial ${trial+1} of ${TOTAL_TRIALS}`;
+    }
+
+    function disableGuesses(){
+      guessEnabled=false;
+      document.querySelectorAll('.color-box').forEach(b=>b.classList.add('disabled'));
+      document.getElementById('color-section').style.display='none';
+    }
+
+    function resetTrials(){
+      trial = 0;
+      matchCount = 0;
+      trialsThisRound = 0;
+      cycleCount = 0;
+      document.getElementById('history').innerHTML = '';
+      document.getElementById('status').textContent = `Trial 1 of ${TOTAL_TRIALS}`;
+      document.querySelectorAll('.color-box').forEach(b=>{
+        b.removeEventListener('click', handleGuess);
+        b.addEventListener('click', handleGuess);
+      });
+      disableGuesses();
+      startGameCycle();
+    }
+
+    document.getElementById('reset-trials').addEventListener('click',()=>{
+      document.getElementById('reset-modal').style.display='block';
+    });
+    document.getElementById('reset-yes').addEventListener('click',()=>{
+      document.getElementById('reset-modal').style.display='none';
+      resetTrials();
+    });
+    document.getElementById('reset-no').addEventListener('click',()=>{
+      document.getElementById('reset-modal').style.display='none';
+    });
+
+    // Relax cycle
+    const pastelColors=['#ffd1dc','#e6e6fa','#d0f0c0','#fdfd96','#ffe5b4','#c1e1c1'];
+    let colorIndex=0, colorInterval, countdownInterval;
+    const relaxAudioFiles=['relax.mp3','relax1.mp3','relax2.mp3'];
+    let relaxAudioIndex=parseInt(localStorage.getItem('relax_music_index')||'0');
+    let relaxMusicPlaying = localStorage.getItem('relax_music_playing') === '1';
+
+    function updateRelaxMute(){
+      document.getElementById('relax-music').textContent = relaxMusicPlaying ? 'Mute Off' : 'Mute On';
+    }
+
+    function startRelaxCycle(){
+      document.getElementById('puzzle-container').style.display='none';
+      document.getElementById('relax-modal').style.display='block';
+      const audio=document.getElementById('relax-audio');
+      audio.loop=true;
+      audio.src=relaxAudioFiles[relaxAudioIndex];
+      if(relaxMusicPlaying){
+        audio.play().catch(()=>{});
+      }
+      updateRelaxMute();
+      const circle=document.getElementById('relax-circle');
+      circle.style.animation='none';
+      void circle.offsetWidth;
+      circle.style.animation='grow-shrink 12s linear 2 forwards';
+      circle.style.backgroundColor=pastelColors[0];
+      colorIndex=0;
+      colorInterval=setInterval(()=>{
+        colorIndex++;
+        circle.style.backgroundColor=pastelColors[colorIndex%pastelColors.length];
+      },2000);
+      let remaining=24;
+      document.getElementById('relax-countdown').textContent=remaining;
+      countdownInterval=setInterval(()=>{
+        remaining--;
+        document.getElementById('relax-countdown').textContent=remaining;
+        if(remaining<=0) finishRelaxCycle();
+      },1000);
+    }
+
+    function finishRelaxCycle(){
+      clearInterval(colorInterval);
+      clearInterval(countdownInterval);
+      document.getElementById('relax-modal').style.display='none';
+      enableGuesses();
+    }
+
+    document.getElementById('relax-music').addEventListener('click',()=>{
+      const audio=document.getElementById('relax-audio');
+      if(audio.paused){
+        audio.play();
+        relaxMusicPlaying=true;
+      }else{
+        audio.pause();
+        relaxMusicPlaying=false;
+      }
+      localStorage.setItem('relax_music_playing',relaxMusicPlaying?'1':'0');
+      updateRelaxMute();
+    });
+
+    document.getElementById('relax-sound').addEventListener('click',()=>{
+      const audio=document.getElementById('relax-audio');
+      relaxAudioIndex=(relaxAudioIndex+1)%relaxAudioFiles.length;
+      localStorage.setItem('relax_music_index',relaxAudioIndex);
+      audio.src=relaxAudioFiles[relaxAudioIndex];
+      if(relaxMusicPlaying){
+        audio.play().catch(()=>{});
+      }
+    });
+
+    // Tetris puzzle
+    const ROWS=20, COLS=10;
+    const INITIAL_SHAPES = 7;
+    const PIECES_PER_ROUND = 10;
+    let board=[], piece=[], pieceRow=0, pieceCol=0, dropInterval, piecesDropped=0;
+    const shapes=[
+      [[0,1,0],[1,1,1]],
+      [[1,1,1,1]],
+      [[1,0,0],[1,1,1]],
+      [[0,0,1],[1,1,1]],
+      [[1,1],[1,1]],
+      [[0,1,1],[1,1,0]],
+      [[1,1,0],[0,1,1]]
+    ];
+
+    function createBoard(){
+      board = Array.from({length:ROWS},()=>Array(COLS).fill(0));
+    }
+
+    function placeInitialShapes(count){
+      for(let i=0;i<count;i++){
+        let mat = JSON.parse(JSON.stringify(shapes[Math.floor(Math.random()*shapes.length)]));
+        const rotations=Math.floor(Math.random()*4);
+        for(let r=0;r<rotations;r++) mat=rotate(mat);
+        let col=Math.floor(Math.random()*(COLS-mat[0].length+1));
+        let row=0;
+        while(valid(row+1,col,mat)) row++;
+        for(let r=0;r<mat.length;r++){
+          for(let c=0;c<mat[r].length;c++){
+            if(mat[r][c]) board[row+r][col+c]=1;
+          }
+        }
+      }
+      applyGravity();
+    }
+
+    function applyGravity(){
+      for(let c=0;c<COLS;c++){
+        let writeRow=ROWS-1;
+        for(let r=ROWS-1;r>=0;r--){
+          if(board[r][c]){
+            if(r!==writeRow){
+              board[writeRow][c]=board[r][c];
+              board[r][c]=0;
+            }
+            writeRow--;
+          }
+        }
+      }
+    }
+
+    function rotate(mat){
+      return mat[0].map((_,i)=>mat.map(row=>row[i]).reverse());
+    }
+
+    function valid(row,col,mat){
+      for(let r=0;r<mat.length;r++){
+        for(let c=0;c<mat[r].length;c++){
+          if(mat[r][c]){
+            let nr=row+r, nc=col+c;
+            if(nr<0 || nr>=ROWS || nc<0 || nc>=COLS) return false;
+            if(board[nr][nc]) return false;
+          }
+        }
+      }
+      return true;
+    }
+
+    function clearLines(){
+      for(let r=ROWS-1;r>=0;r--){
+        if(board[r].every(v=>v)){
+          board.splice(r,1);
+          board.unshift(Array(COLS).fill(0));
+          r++;
+        }
+      }
+    }
+
+    function boardIsEmpty(){
+      for(let r=0;r<ROWS;r++){
+        for(let c=0;c<COLS;c++){
+          if(board[r][c]) return false;
+        }
+      }
+      return true;
+    }
+
+    function draw(){
+      const container=document.getElementById('tetris');
+      container.innerHTML='';
+      for(let r=0;r<ROWS;r++){
+        for(let c=0;c<COLS;c++){
+          const div=document.createElement('div');
+          div.className='cell';
+          if(board[r][c]) div.classList.add('filled');
+          container.appendChild(div);
+        }
+      }
+      const cells=container.querySelectorAll('.cell');
+      for(let r=0;r<piece.length;r++){
+        for(let c=0;c<piece[r].length;c++){
+          if(piece[r][c]){
+            const idx=(pieceRow+r)*COLS+(pieceCol+c);
+            if(cells[idx]) cells[idx].classList.add('piece');
+          }
+        }
+      }
+    }
+
+    function spawnPiece(){
+      piece = JSON.parse(JSON.stringify(shapes[Math.floor(Math.random()*shapes.length)]));
+      pieceRow = 0;
+      pieceCol = Math.floor(COLS/2) - Math.ceil(piece[0].length/2);
+      return valid(pieceRow, pieceCol, piece);
+    }
+
+    function move(dx,dy){
+      if(valid(pieceRow+dy,pieceCol+dx,piece)){
+        pieceRow+=dy; pieceCol+=dx; draw(); return true;
+      }
+      return false;
+    }
+
+    function drop(){
+      if(!move(0,1)) lockPiece();
+    }
+
+    function lockPiece(){
+      for(let r=0;r<piece.length;r++){
+        for(let c=0;c<piece[r].length;c++){
+          if(piece[r][c]) board[pieceRow+r][pieceCol+c]=1;
+        }
+      }
+      clearLines();
+      if(boardIsEmpty()){
+        puzzleComplete();
+        return;
+      }
+      piecesDropped++;
+      clearInterval(dropInterval);
+      if(board[0].some(v=>v)){
+        puzzleComplete();
+        return;
+      }
+      if(piecesDropped>=PIECES_PER_ROUND){
+        puzzleComplete();
+      }else{
+        if(spawnPiece()){
+          draw();
+          dropInterval=setInterval(drop,250);
+        }else{
+          puzzleComplete();
+        }
+      }
+    }
+
+    function puzzleComplete(){
+      document.getElementById('puzzle-status').textContent='Puzzle complete!';
+      clearInterval(dropInterval);
+      startRelaxCycle();
+    }
+
+    function startPuzzle(){
+      document.getElementById('puzzle-container').style.display='block';
+      document.getElementById('puzzle-status').textContent='Solve the puzzle';
+      createBoard();
+      placeInitialShapes(INITIAL_SHAPES);
+      piecesDropped=0;
+      if(spawnPiece()){
+        draw();
+        dropInterval=setInterval(drop,250);
+      }else{
+        puzzleComplete();
+      }
+    }
+
+    document.addEventListener('keydown',e=>{
+      if(!dropInterval) return;
+      if(e.key==='ArrowLeft') move(-1,0);
+      else if(e.key==='ArrowRight') move(1,0);
+      else if(e.key==='ArrowUp'){
+        const rot=rotate(piece);
+        if(valid(pieceRow,pieceCol,rot)){ piece=rot; draw(); }
+      }else if(e.key==='ArrowDown') drop();
+    });
+
+    const tetrisDiv=document.getElementById('tetris');
+    let dragStartX=0, dragCurrentX=0, dragMoved=false, dragging=false;
+
+    tetrisDiv.addEventListener('pointerdown',e=>{
+      if(!dropInterval) return;
+      dragging=true;
+      dragStartX=dragCurrentX=e.clientX;
+      dragMoved=false;
+    });
+
+    tetrisDiv.addEventListener('pointermove',e=>{
+      if(!dragging) return;
+      let dx=e.clientX-dragCurrentX;
+      while(Math.abs(dx)>=20){
+        if(move(dx>0?1:-1,0)){
+          dragCurrentX+=dx>0?20:-20;
+        }else{
+          break;
+        }
+        dx=e.clientX-dragCurrentX;
+        dragMoved=true;
+      }
+    });
+
+    function handlePointerEnd(){
+      if(!dragging) return;
+      if(!dragMoved){
+        const rot=rotate(piece);
+        if(valid(pieceRow,pieceCol,rot)){ piece=rot; draw(); }
+      }
+      dragging=false;
+    }
+
+    tetrisDiv.addEventListener('pointerup',handlePointerEnd);
+    tetrisDiv.addEventListener('pointercancel',()=>{dragging=false;});
+
+    const puzzleAudioFiles=['relax.mp3','relax1.mp3','relax2.mp3'];
+    let puzzleAudioIndex=parseInt(localStorage.getItem('puzzle_music_index')||'0');
+    let puzzleMusicPlaying=localStorage.getItem('puzzle_music_playing')==='1';
+
+    function updatePuzzleMute(){
+      document.getElementById('puzzle-music').textContent=puzzleMusicPlaying?'Mute Off':'Mute On';
+    }
+
+    document.getElementById('puzzle-music').addEventListener('click',()=>{
+      const audio=document.getElementById('puzzle-audio');
+      if(audio.paused){
+        audio.play();
+        puzzleMusicPlaying=true;
+      }else{
+        audio.pause();
+        puzzleMusicPlaying=false;
+      }
+      localStorage.setItem('puzzle_music_playing',puzzleMusicPlaying?'1':'0');
+      updatePuzzleMute();
+    });
+
+    document.getElementById('puzzle-sound').addEventListener('click',()=>{
+      const audio=document.getElementById('puzzle-audio');
+      puzzleAudioIndex=(puzzleAudioIndex+1)%puzzleAudioFiles.length;
+      localStorage.setItem('puzzle_music_index',puzzleAudioIndex);
+      audio.src=puzzleAudioFiles[puzzleAudioIndex];
+      if(puzzleMusicPlaying){
+        audio.play().catch(()=>{});
+      }
+    });
+
+    updatePuzzleMute();
+    const initAudio=document.getElementById('puzzle-audio');
+    initAudio.loop=true;
+    initAudio.src=puzzleAudioFiles[puzzleAudioIndex];
+    if(puzzleMusicPlaying){
+      initAudio.play().catch(()=>{});
+    }
+
+    function startGameCycle(){
+      if(cycleCount>=TOTAL_CYCLES) return;
+      cycleCount++;
+      document.getElementById('relax-cycle').textContent=`${cycleCount}/${TOTAL_CYCLES}`;
+      startPuzzle();
+    }
+
+    startGameCycle();
+  </script>
+  <script>
+    document.getElementById("menu-toggle").addEventListener("click", () => {
+      document.getElementById("menu").classList.toggle("expanded");
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `hybridguesser.html` that combines the Tetris puzzle from Beta Guesser with the relax circle from Relax Guesser
- after solving the puzzle, the page plays a relax round then enables four guesses
- cycle repeats until all 24 trials complete

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687862ff1738832684bea3d26d726f94