### PR TITLE
Fix iOS zoom on Hybrid Guesser Tetris buttons

### DIFF
--- a/hybridguesser.html
+++ b/hybridguesser.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
   <title>Hybrid Guesser</title>
   <style>
     body {
@@ -22,6 +22,7 @@
       border-radius: 8px;
       box-shadow: 0 2px 4px rgba(0,0,0,0.3);
       cursor: pointer;
+      touch-action: manipulation;
     }
     button:hover { opacity: 0.9; }
     #game-panel {


### PR DESCRIPTION
## Summary
- prevent Safari from zooming when tapping the Tetris controls

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6878e27fa4688326b683596ca57fc7e5