### PR TITLE
Keep Betaguesser color panel visible while locked

### DIFF
--- a/betaguesser.html
+++ b/betaguesser.html
@@ -59,7 +59,8 @@
     }
     .filled { background:#666; }
     .piece { background:#ff6666; }
-    #color-section { display:none; }
+    /* Color section should remain visible but locked until the puzzle is solved */
+    #color-section { display:block; }
     #color-boxes {
       display: flex;
       justify-content: center;
@@ -260,7 +261,8 @@
     function disableGuesses(){
       guessEnabled=false;
       document.querySelectorAll('.color-box').forEach(b=>b.classList.add('disabled'));
-      document.getElementById('color-section').style.display='none';
+      // keep the color section visible but inputs inactive
+      document.getElementById('color-section').style.display='block';
     }
 
     function resetTrials(){
@@ -571,6 +573,8 @@
       initAudio.play().catch(()=>{});
     }
 
+    // initially lock the color choices until the puzzle is solved
+    disableGuesses();
     startPuzzle();
   </script>
   <script>


### PR DESCRIPTION
## Summary
- keep the color choice section visible in betaguesser
- lock the choices until the Tetris puzzle finishes
- lock again for the next puzzle round

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6878e783f7048326b213cd93e535961d